### PR TITLE
Added test assembly and very basic logic test around board init

### DIFF
--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85bda19c72e773c46a19d8add594051a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/LogicTests.cs
+++ b/Assets/Tests/LogicTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Tests
+{
+    public class LogicTests
+    {
+        public const int validBoardSizeMin = 3;
+        public const int validBoardSizeMax = 8; // inclusive
+
+        public static IEnumerable<TestCaseData> AllValidEmptyBoardStates
+        {
+            get
+            {
+                for (int size = validBoardSizeMin; size <= validBoardSizeMax; ++size)
+                    yield return new TestCaseData(new TakLogic.BoardState(size)).SetName($"Empty board with {size}");
+            }
+        }
+
+        [Test]
+        public void BoardState_BoardSetup_IsNotNull_ForValidSizes([Range(validBoardSizeMin, validBoardSizeMax)] int size)
+        {
+            Assert.That(TakLogic.BoardState.GetBoardSetup(size), Is.Not.Null);
+        }
+
+        [Test]
+        public void BoardState_BoardSetup_IsNull_ForInvalidSizes([Values(-1, 0, 1, 2, 9, 10, int.MaxValue, int.MinValue)] int size)
+        {
+            Assert.That(TakLogic.BoardState.GetBoardSetup(size), Is.Null);
+        }
+
+        [Test, TestCaseSource(nameof(AllValidEmptyBoardStates))]
+        public void BoardState_IsValid_OnCreation(TakLogic.BoardState board)
+        {
+            Assert.That(board.VerifyState(), Is.True);
+        }
+    }
+}

--- a/Assets/Tests/LogicTests.cs.meta
+++ b/Assets/Tests/LogicTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77d498d45e4577e4498ef4d637e2db68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Tests.asmdef
+++ b/Assets/Tests/Tests.asmdef
@@ -1,0 +1,21 @@
+{
+    "name": "Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "TakLogic"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Tests.asmdef.meta
+++ b/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 761c1421cd37a7046bf65738bd94ef07
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
As you asked for, here's a test assembly with a simple test which starts stabbing at BoardState, only at init logic so far.
Reveals `VerifyState` is not working right now.